### PR TITLE
Respect Canceled Events

### DIFF
--- a/src/JackMD/AutoXP/Main.php
+++ b/src/JackMD/AutoXP/Main.php
@@ -54,8 +54,16 @@ class Main extends PluginBase implements Listener{
 		$event->getPlayer()->addXp($event->getXpDropAmount());
 		$event->setXpDropAmount(0);
 	}
-	
+
+
+    /**
+     * @param PlayerDeathEvent $event
+     * @priority HIGHEST
+     */
 	public function onPlayerKill(PlayerDeathEvent $event){
+	    if($event->isCancelled()){
+	        return;
+        }
 		$player = $event->getPlayer();
 		$cause = $player->getLastDamageCause();
 		if($cause instanceof EntityDamageByEntityEvent){

--- a/src/JackMD/AutoXP/Main.php
+++ b/src/JackMD/AutoXP/Main.php
@@ -42,8 +42,15 @@ class Main extends PluginBase implements Listener{
 		$this->getServer()->getPluginManager()->registerEvents(($this), $this);
 		$this->getLogger()->info("Plugin Enabled.");
 	}
-	
+
+    /**
+     * @param BlockBreakEvent $event
+     * @priority HIGHEST
+     */
 	public function onBreak(BlockBreakEvent $event){
+	    if($event->isCancelled()){
+	        return;
+        }
 		$event->getPlayer()->addXp($event->getXpDropAmount());
 		$event->setXpDropAmount(0);
 	}


### PR DESCRIPTION
AutoXP can be abused when used with any plugin that would cancel XP related event.  For instance, if a world protection plugin prevents emerald ore from being broken, players which attempt to mine the protected ore will still receive the XP from it.

This PR aims to fix this by adding a check for the event to be canceled in onBreak and onPlayerKill methods.  In addition, these methods have been given a priority of HIGHEST to ensure they are called during the last stages of processing the event.  This will ensure the maximum number of plugins have been processed first and give AutoXP a chance to respond to any modifications to the event from those plugins.