### PR TITLE
Remove check for canceled PlayerDeathEvent

### DIFF
--- a/src/JackMD/AutoXP/Main.php
+++ b/src/JackMD/AutoXP/Main.php
@@ -36,39 +36,39 @@ use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
 
-class Main extends PluginBase implements Listener{
-	
-	public function onEnable(): void{
+class Main extends PluginBase implements Listener {
+
+	public function onEnable(): void {
 		$this->getServer()->getPluginManager()->registerEvents(($this), $this);
 		$this->getLogger()->info("Plugin Enabled.");
 	}
 
-    /**
-     * @param BlockBreakEvent $event
-     * @priority HIGHEST
-     */
-	public function onBreak(BlockBreakEvent $event){
-	    if($event->isCancelled()){
-	        return;
-        }
+	/**
+	 * @param BlockBreakEvent $event
+	 * @priority HIGHEST
+	 */
+	public function onBreak(BlockBreakEvent $event) {
+		if ($event->isCancelled()) {
+			return;
+		}
 		$event->getPlayer()->addXp($event->getXpDropAmount());
 		$event->setXpDropAmount(0);
 	}
 
 
-    /**
-     * @param PlayerDeathEvent $event
-     * @priority HIGHEST
-     */
-	public function onPlayerKill(PlayerDeathEvent $event){
-	    if($event->isCancelled()){
-	        return;
-        }
+	/**
+	 * @param PlayerDeathEvent $event
+	 * @priority HIGHEST
+	 */
+	public function onPlayerKill(PlayerDeathEvent $event) {
+		if ($event->isCancelled()) {
+			return;
+		}
 		$player = $event->getPlayer();
 		$cause = $player->getLastDamageCause();
-		if($cause instanceof EntityDamageByEntityEvent){
+		if ($cause instanceof EntityDamageByEntityEvent) {
 			$damager = $cause->getDamager();
-			if($damager instanceof Player){
+			if ($damager instanceof Player) {
 				$damager->addXp($player->getXpDropAmount());
 				$player->setCurrentTotalXp(0);
 			}

--- a/src/JackMD/AutoXP/Main.php
+++ b/src/JackMD/AutoXP/Main.php
@@ -61,9 +61,6 @@ class Main extends PluginBase implements Listener {
 	 * @priority HIGHEST
 	 */
 	public function onPlayerKill(PlayerDeathEvent $event) {
-		if ($event->isCancelled()) {
-			return;
-		}
 		$player = $event->getPlayer();
 		$cause = $player->getLastDamageCause();
 		if ($cause instanceof EntityDamageByEntityEvent) {


### PR DESCRIPTION
This removes the check for a canceled PlayerDeathEvent and closes #5 